### PR TITLE
Check for empty or non-existent sources section in config parsing

### DIFF
--- a/scripts/xbstrap
+++ b/scripts/xbstrap
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
-from collections.abc import Iterable
 from enum import Enum
 import errno
 import os
@@ -98,32 +97,32 @@ class Config:
 		self._tool_stages = dict()
 		self._target_pkgs = dict()
 
-		if 'sources' in self._root_yml and isinstance(self._root_yml['sources'], Iterable):
+		if 'sources' in self._root_yml and isinstance(self._root_yml['sources'], list):
 			for src_yml in self._root_yml['sources']:
 				src = Source(self, None, src_yml)
 				if src.name in self._sources:
 					raise RuntimeError("Duplicate source")
 				self._sources[src.name] = src
-		for pkg_yml in self._root_yml['tools']:
-			if 'source' in pkg_yml:
-				src = Source(self, pkg_yml['name'], pkg_yml['source'])
-				if src.name in self._sources:
-					raise RuntimeError("Duplicate source")
-				self._sources[src.name] = src
-		for pkg_yml in self._root_yml['packages']:
-			if 'source' in pkg_yml:
-				src = Source(self, pkg_yml['name'], pkg_yml['source'])
-				if src.name in self._sources:
-					raise RuntimeError("Duplicate source")
-				self._sources[src.name] = src
 
-		for pkg_yml in self._root_yml['tools']:
-			pkg = HostPackage(self, pkg_yml)
-			self._tool_pkgs[pkg.name] = pkg
+		if 'tools' in self._root_yml and isinstance(self._root_yml['tools'], list):
+			for pkg_yml in self._root_yml['tools']:
+				if 'source' in pkg_yml:
+					src = Source(self, pkg_yml['name'], pkg_yml['source'])
+					if src.name in self._sources:
+						raise RuntimeError("Duplicate source")
+					self._sources[src.name] = src
+				pkg = HostPackage(self, pkg_yml)
+				self._tool_pkgs[pkg.name] = pkg
 
-		for pkg_yml in self._root_yml['packages']:
-			pkg = TargetPackage(self, pkg_yml)
-			self._target_pkgs[pkg.name] = pkg
+		if 'packages' in self._root_yml and isinstance(self._root_yml['packages'], list):
+			for pkg_yml in self._root_yml['packages']:
+				if 'source' in pkg_yml:
+					src = Source(self, pkg_yml['name'], pkg_yml['source'])
+					if src.name in self._sources:
+						raise RuntimeError("Duplicate source")
+					self._sources[src.name] = src
+				pkg = TargetPackage(self, pkg_yml)
+				self._target_pkgs[pkg.name] = pkg
 
 	@property
 	def repository_url(self):

--- a/scripts/xbstrap
+++ b/scripts/xbstrap
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import argparse
+from collections.abc import Iterable
 from enum import Enum
 import errno
 import os
@@ -97,11 +98,12 @@ class Config:
 		self._tool_stages = dict()
 		self._target_pkgs = dict()
 
-		for src_yml in self._root_yml['sources']:
-			src = Source(self, None, src_yml)
-			if src.name in self._sources:
-				raise RuntimeError("Duplicate source")
-			self._sources[src.name] = src
+		if 'sources' in self._root_yml and isinstance(self._root_yml['sources'], Iterable):
+			for src_yml in self._root_yml['sources']:
+				src = Source(self, None, src_yml)
+				if src.name in self._sources:
+					raise RuntimeError("Duplicate source")
+				self._sources[src.name] = src
 		for pkg_yml in self._root_yml['tools']:
 			if 'source' in pkg_yml:
 				src = Source(self, pkg_yml['name'], pkg_yml['source'])

--- a/scripts/xbstrap
+++ b/scripts/xbstrap
@@ -514,10 +514,13 @@ class TargetPackage(RequirementsMixin):
 		self._configure_steps = [ ]
 		self._build_steps = [ ]
 
-		for step_yml in self._this_yml['configure']:
-			self._configure_steps.append(ScriptStep(step_yml))
-		for step_yml in self._this_yml['build']:
-			self._build_steps.append(ScriptStep(step_yml))
+		if 'configure' in self._this_yml:
+			for step_yml in self._this_yml['configure']:
+				self._configure_steps.append(ScriptStep(step_yml))
+
+		if 'build' in self._this_yml:
+			for step_yml in self._this_yml['build']:
+				self._build_steps.append(ScriptStep(step_yml))
 
 	@property
 	def source(self):


### PR DESCRIPTION
Consider this minor cosmetics. This makes sure building doesn't fail if there are no declared sources.