### PR TITLE
Add preliminary support for svn repo's

### DIFF
--- a/xbstrap/base.py
+++ b/xbstrap/base.py
@@ -1235,8 +1235,11 @@ def checkout_src(cfg, src, settings):
 			args.append(source['branch'])
 		subprocess.check_call(args, cwd=src.source_dir)
 	elif 'svn' in source:
-		# do nothing here? I need a no-op
-		print()
+		args = ['svn', 'update']
+		if 'rev' in source:
+			args.append('-r')
+			args.append(source['rev'])
+		subprocess.check_call(args, cwd=src.source_dir)
 	else:
 		if src.source_archive_format == 'raw' and 'filename' in source:
 			shutil.copyfile(src.source_archive_file, os.path.join(src.sub_dir, src.name, source['filename']))

--- a/xbstrap/base.py
+++ b/xbstrap/base.py
@@ -519,6 +519,9 @@ class Source(RequirementsMixin):
 				args.append(self._this_yml['branch'])
 			if subprocess.call(args, cwd=self.source_dir, stdout=subprocess.DEVNULL) != 0:
 				return ItemState(missing=True)
+		elif 'svn' in self._this_yml:
+			if not os.path.isdir(self.source_dir):
+				return ItemState(missing=True)
 		else:
 			assert 'url' in self._this_yml
 			if not os.access(self.source_archive_file, os.F_OK):
@@ -1182,6 +1185,11 @@ def fetch_src(cfg, src):
 		try_mkdir(src.source_dir)
 		args = ['hg', 'clone', source['hg'], src.source_dir]
 		subprocess.check_call(args)
+	elif 'svn' in source:
+		try_mkdir(src.source_dir)
+		args = ['svn', 'co', source['svn'], src.source_dir]
+		print (args)
+		subprocess.check_call(args)
 	else:
 		assert 'url' in source
 
@@ -1226,6 +1234,9 @@ def checkout_src(cfg, src, settings):
 		else:
 			args.append(source['branch'])
 		subprocess.check_call(args, cwd=src.source_dir)
+	elif 'svn' in source:
+		# do nothing here? I need a no-op
+		print()
 	else:
 		if src.source_archive_format == 'raw' and 'filename' in source:
 			shutil.copyfile(src.source_archive_file, os.path.join(src.sub_dir, src.name, source['filename']))


### PR DESCRIPTION
This PR adds preliminary support for svn repo's
An svn repo can be used only with trunk, checking out tags is not possible at the moment, but for the current use case, this suffices.
Future improvements to allow checking out tags and support patching of svn repo's is something to consider