### PR TITLE
Prepare for xbbs incremental builds

### DIFF
--- a/scripts/xbstrap-pipeline
+++ b/scripts/xbstrap-pipeline
@@ -97,13 +97,12 @@ def do_compute_graph(args):
 	cfg = xbstrap.base.config_for_dir()
 	pipe = pipeline_for_dir(cfg)
 
+	with xbstrap.cli_utils.open_file_from_cli(args.version_file, 'rt') as f:
+		version_yml = yaml.load(f, yaml.SafeLoader)
 	if args.artifacts:
 		out_root = dict()
 		for job in pipe.all_jobs():
 			if args.version_file:
-				with xbstrap.cli_utils.open_file_from_cli(args.version_file, 'rt') as f:
-					version_yml = yaml.load(f, yaml.SafeLoader)
-
 				up2date = True
 				if len(job.tools): # For now, tools are always rebuilt.
 					up2date = False

--- a/scripts/xbstrap-pipeline
+++ b/scripts/xbstrap-pipeline
@@ -107,6 +107,8 @@ def do_compute_graph(args):
 				up2date = True
 				if len(job.tools): # For now, tools are always rebuilt.
 					up2date = False
+				if len(job.tasks): # For now, tasks are also always rebuilt.
+					up2date = False
 				for pkg in job.pkgs:
 					if pkg.name not in version_yml['pkgs']:
 						up2date = False

--- a/scripts/xbstrap-pipeline
+++ b/scripts/xbstrap-pipeline
@@ -102,6 +102,7 @@ def do_compute_graph(args):
 	if args.artifacts:
 		out_root = dict()
 		for job in pipe.all_jobs():
+			up2date = False
 			if args.version_file:
 				up2date = True
 				if len(job.tools): # For now, tools are always rebuilt.
@@ -113,8 +114,6 @@ def do_compute_graph(args):
 					if pkg.version != version_yml['pkgs'][pkg.name]:
 						up2date = False
 						break
-				if up2date:
-					continue
 
 			plan = xbstrap.base.Plan(cfg)
 			plan.build_scope = set().union(job.tools, job.pkgs)
@@ -129,7 +128,10 @@ def do_compute_graph(args):
 				plan.wanted.update([(xbstrap.base.Action.RUN, task)])
 			plan.compute_plan(no_ordering=True)
 
-			out_job = {'unstable': job.unstable}
+			out_job = {
+				'unstable': job.unstable,
+				'up2date': up2date
+			}
 			out_job['products'] = {'tools': [], 'pkgs': [], 'files': []}
 			out_job['needed'] = {'tools': [], 'pkgs': []}
 			for tool in job.tools:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,7 @@
-
 [metadata]
 description-file = README.md
 
+[flake8]
+# there are many more warnings that are emitted by flake that should be
+# ignored, but I think it's better to address them and this both.
+ignore = W191


### PR DESCRIPTION
- a fix for a bug that caused the version-file to be re-read many times, causing it to break on pipes
- adding up2date to graph, to not emit incomplete graphs
- add flake8 configuration to setup.cfg, to ignore the non-pep8 indentation choices
- make batches with tasks always out of date