### PR TITLE
Support cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,25 @@ If the `configure` script shall be run again, use instead:
 ```
 xbstrap install --reconfigure foobar
 ```
+
+## Local development
+
+To install your local copy, run the following command:
+```
+pip install --user -e .
+```
+
+### Using Docker
+
+For containerized builds, most `xbstrap` commands will run in two stages: once on the host, then again on the container to
+actually execute the build steps. Therefore, installing `xbstrap` locally (as shown above) is not sufficient in this case.
+
+In addition, you must change the `Dockerfile` so that instead of grabbing `xbstrap` from the `pip` repositories, it installs from the host:
+1. Remove the `pip3 install xbstrap` line.
+1. Add the following lines:
+```docker
+ADD xbstrap /var/bootstrap-managarm/local-xbstrap
+RUN pip3 install -e /var/bootstrap-managarm/local-xbstrap
+```
+1. Copy or symlink your local `xbstrap` into `src/docker`, so that it can be accessed by the previous step.
+1. Rebuild the docker container as usual with `docker build -t managarm-buildenv --build-arg=USER=$(id -u) src/docker`

--- a/README.md
+++ b/README.md
@@ -36,22 +36,21 @@ xbstrap install --reconfigure foobar
 
 ## Local development
 
-To install your local copy, run the following command:
+When developing `xbstrap`, you must install your local copy instead of the one provided by the `pip` repositories. To do this, run:
 ```
 pip install --user -e .
 ```
 
-### Using Docker
+### Development with Docker
 
 For containerized builds, most `xbstrap` commands will run in two stages: once on the host, then again on the container to
 actually execute the build steps. Therefore, installing `xbstrap` locally (as shown above) is not sufficient in this case.
 
-In addition, you must change the `Dockerfile` so that instead of grabbing `xbstrap` from the `pip` repositories, it installs from the host:
-1. Remove the `pip3 install xbstrap` line.
-1. Add the following lines:
+In addition, you must change your `Dockerfile` so that instead of grabbing `xbstrap` from the `pip` repositories, it installs from the host:
+1. Add the following lines (replace `/local-xbstrap` at your convenience):
 ```docker
-ADD xbstrap /var/bootstrap-managarm/local-xbstrap
-RUN pip3 install -e /var/bootstrap-managarm/local-xbstrap
+ADD xbstrap /local-xbstrap
+RUN pip3 install -e /local-xbstrap
 ```
-1. Copy or symlink your local `xbstrap` into `src/docker`, so that it can be accessed by the previous step.
-1. Rebuild the docker container as usual with `docker build -t managarm-buildenv --build-arg=USER=$(id -u) src/docker`
+1. Copy or symlink your local `xbstrap` into the same folder that contains the `Dockerfile`, so that it can be accessed by the previous step.
+1. Rebuild the docker container as usual.

--- a/scripts/xbstrap
+++ b/scripts/xbstrap
@@ -67,28 +67,32 @@ def do_init(args):
 	else:
 		os.symlink(os.path.join(args.src_root, 'bootstrap.yml'), 'bootstrap.link')
 
-
-	print('Creating cargo-home/config.toml')
-	os.makedirs('cargo-home', exist_ok=True)
-	shutil.copy(os.path.join(args.src_root, 'extrafiles/config.toml'),
-		    'cargo-home/config.toml')
-
 	cfg = xbstrap.base.config_for_dir()
-	container = cfg._site_yml.get('container', dict())
+	if cfg.cargo_config_toml is not None:
+		print('Creating cargo-home/config.toml')
+		os.makedirs('cargo-home', exist_ok=True)
+		shutil.copy(cfg.cargo_config_toml, 'cargo-home/config.toml')
 
-	try:
-		build_root = container['build_mount']
-	except KeyError:
-		print('Using non-Docker build')
-		build_root = os.getcwd()
+		container = cfg._site_yml.get('container', dict())
+		if 'build_mount' in container:
+			build_root = container['build_mount']
+			source_root = container['src_mount']
+		else:
+			print('Using non-Docker build')
+			build_root = os.getcwd()
+			source_root = os.path.abspath(args.src_root)
 
-	with open('cargo-home/config.toml', 'r') as f:
-		content = f.read()
-		content = content.replace("@BUILD_ROOT@", build_root)
-		content = content.replace("@SRC_ROOT@", args.src_root)
+		with open('cargo-home/config.toml', 'r') as f:
+			def substitute(varname):
+				if varname == 'SOURCE_ROOT':
+					return source_root
+				elif varname == 'BUILD_ROOT':
+					return build_root
 
-	with open('cargo-home/config.toml', 'w') as f:
-		f.write(content)
+			content = xbstrap.base.replace_at_vars(f.read(), substitute)
+
+		with open('cargo-home/config.toml', 'w') as f:
+			f.write(content)
 
 do_init.parser = main_subparsers.add_parser('init')
 do_init.parser.add_argument('src_root', type=str)

--- a/scripts/xbstrap
+++ b/scripts/xbstrap
@@ -61,7 +61,28 @@ do_runtool.parser.add_argument('opts', nargs=argparse.REMAINDER)
 def do_init(args):
 	if not os.access(os.path.join(args.src_root, 'bootstrap.yml'), os.F_OK):
 		raise RuntimeError("Given src_root does not contain a bootstrap.yml")
-	os.symlink(os.path.join(args.src_root, 'bootstrap.yml'), 'bootstrap.link')
+	elif os.path.exists('bootstrap.link'):
+		print('warning: bootstrap.link already exists, skipping...')
+	else:
+		os.symlink(os.path.join(args.src_root, 'bootstrap.yml'), 'bootstrap.link')
+
+	print('Creating cargo-home/config.toml')
+	os.makedirs('cargo-home', exist_ok=True)
+	with open('cargo-home/config.toml', 'w') as f:
+		rustc_path  = '../../../build/tools/host-rust/bin/rustc'
+		linker_path = 'tools/system-gcc/bin/x86_64-managarm-gcc'
+		f.write(
+'''
+paths = ["../src/ports/rust-libc"]
+
+[build]
+rustc = "%s"
+target = "x86_64-unknown-managarm-system"
+
+[target.x86_64-unknown-managarm-system]
+linker = "%s"
+''' % (rustc_path, linker_path)
+		)
 
 do_init.parser = main_subparsers.add_parser('init')
 do_init.parser.add_argument('src_root', type=str)

--- a/scripts/xbstrap
+++ b/scripts/xbstrap
@@ -7,6 +7,7 @@ import os
 import sys
 import urllib.parse
 import tarfile
+import shutil
 
 import colorama
 import xbstrap.base
@@ -66,23 +67,28 @@ def do_init(args):
 	else:
 		os.symlink(os.path.join(args.src_root, 'bootstrap.yml'), 'bootstrap.link')
 
+
 	print('Creating cargo-home/config.toml')
 	os.makedirs('cargo-home', exist_ok=True)
+	shutil.copy(os.path.join(args.src_root, 'extrafiles/config.toml'),
+		    'cargo-home/config.toml')
+
+	cfg = xbstrap.base.config_for_dir()
+	container = cfg._site_yml.get('container', dict())
+
+	try:
+		build_root = container['build_mount']
+	except KeyError:
+		print('Using non-Docker build')
+		build_root = os.getcwd()
+
+	with open('cargo-home/config.toml', 'r') as f:
+		content = f.read()
+		content = content.replace("@BUILD_ROOT@", build_root)
+		content = content.replace("@SRC_ROOT@", args.src_root)
+
 	with open('cargo-home/config.toml', 'w') as f:
-		rustc_path  = '../../../build/tools/host-rust/bin/rustc'
-		linker_path = 'tools/system-gcc/bin/x86_64-managarm-gcc'
-		f.write(
-'''
-paths = ["../src/ports/rust-libc"]
-
-[build]
-rustc = "%s"
-target = "x86_64-unknown-managarm-system"
-
-[target.x86_64-unknown-managarm-system]
-linker = "%s"
-''' % (rustc_path, linker_path)
-		)
+		f.write(content)
 
 do_init.parser = main_subparsers.add_parser('init')
 do_init.parser.add_argument('src_root', type=str)

--- a/scripts/xbstrap
+++ b/scripts/xbstrap
@@ -71,7 +71,7 @@ def do_init(args):
 	if cfg.cargo_config_toml is not None:
 		print('Creating cargo-home/config.toml')
 		os.makedirs('cargo-home', exist_ok=True)
-		shutil.copy(cfg.cargo_config_toml, 'cargo-home/config.toml')
+		shutil.copy(os.path.join(args.src_root, cfg.cargo_config_toml), 'cargo-home/config.toml')
 
 		container = cfg._site_yml.get('container', dict())
 		if 'build_mount' in container:

--- a/xbstrap/base.py
+++ b/xbstrap/base.py
@@ -508,6 +508,12 @@ class ScriptStep:
 			return False
 		return self._step_yml['quiet']
 
+	@property
+	def cargo_home(self):
+		if 'cargo_home' not in self._step_yml:
+			return True
+		return self._step_yml['cargo_home']
+
 class RequirementsMixin:
 	@property
 	def source_dependencies(self):
@@ -1465,6 +1471,9 @@ def execute_manifest(manifest):
 	if manifest['quiet']:
 		output = subprocess.DEVNULL
 
+	if manifest['cargo_home']:
+		environ['CARGO_HOME'] = os.path.join(build_root, 'cargo-home')
+
 	# Determine the working directory.
 	if manifest['workdir'] is not None:
 		workdir = replace_at_vars(manifest['workdir'], substitute)
@@ -1492,7 +1501,7 @@ def execute_manifest(manifest):
 
 def run_program(cfg, context, subject, args,
 		tool_pkgs=[], virtual_tools=[], workdir=None, extra_environ=dict(),
-		for_package=False, containerless=False, quiet=False):
+		for_package=False, containerless=False, quiet=False, cargo_home=True):
 	pkg_queue = []
 	pkg_visited = set()
 
@@ -1518,6 +1527,7 @@ def run_program(cfg, context, subject, args,
 		'workdir': workdir,
 		'extra_environ': extra_environ,
 		'quiet': quiet,
+		'cargo_home': cargo_home,
 		'for_package': for_package,
 		'virtual_tools': list(virtual_tools),
 		'tools': [],
@@ -1648,7 +1658,8 @@ def run_step(cfg, context, subject, step, tool_pkgs, virtual_tools,
 			extra_environ=step.environ,
 			for_package=for_package,
 			containerless=step.containerless,
-			quiet=step.quiet and not verbosity)
+			quiet=step.quiet and not verbosity,
+                        cargo_home=step.cargo_home)
 
 def postprocess_libtool(cfg, pkg):
 	for libdir in ['lib', 'lib64', 'lib32', 'usr/lib', 'usr/lib64', 'usr/lib32']:

--- a/xbstrap/base.py
+++ b/xbstrap/base.py
@@ -404,7 +404,7 @@ class Config:
 
 	@property
 	def cargo_config_toml(self):
-		yml = self._site_yml.get('general', dict())
+		yml = self._root_yml.get('general', dict())
 		if 'cargo' in yml:
 			return yml['cargo']['config_toml']
 		else:

--- a/xbstrap/base.py
+++ b/xbstrap/base.py
@@ -403,6 +403,14 @@ class Config:
 			return os.path.join(self.build_root, self._root_yml['directories']['packages'])
 
 	@property
+	def cargo_config_toml(self):
+		yml = self._site_yml.get('general', dict())
+		if 'cargo' in yml:
+			return yml['cargo']['config_toml']
+		else:
+			return None
+
+	@property
 	def all_options(self):
 		for yml in self._root_yml.get('declare_options', []):
 			yield yml['name']
@@ -1527,7 +1535,7 @@ def run_program(cfg, context, subject, args,
 		'workdir': workdir,
 		'extra_environ': extra_environ,
 		'quiet': quiet,
-		'cargo_home': cargo_home,
+		'cargo_home': cfg.cargo_config_toml is not None and cargo_home,
 		'for_package': for_package,
 		'virtual_tools': list(virtual_tools),
 		'tools': [],
@@ -1659,7 +1667,7 @@ def run_step(cfg, context, subject, step, tool_pkgs, virtual_tools,
 			for_package=for_package,
 			containerless=step.containerless,
 			quiet=step.quiet and not verbosity,
-                        cargo_home=step.cargo_home)
+			cargo_home=step.cargo_home)
 
 def postprocess_libtool(cfg, pkg):
 	for libdir in ['lib', 'lib64', 'lib32', 'usr/lib', 'usr/lib64', 'usr/lib32']:

--- a/xbstrap/schema.yml
+++ b/xbstrap/schema.yml
@@ -128,6 +128,8 @@ definitions:
                 'containerless': { type: boolean }
                 'quiet':
                     type: boolean
+                'cargo_home':
+                    type: boolean
 
     'args':
         oneOf:

--- a/xbstrap/schema.yml
+++ b/xbstrap/schema.yml
@@ -151,6 +151,12 @@ properties:
                 type: string
             'everything_by_default':
                 type: boolean
+            'cargo':
+                type: object
+                additionalProperties: false
+                properties:
+                    'config_toml':
+                        type: string
     'repository':
         type: object
         additionalProperties: false


### PR DESCRIPTION
This adds the necessary infrastructure to support `cargo` builds from `xbstrap`:
* `xbstrap init` now creates a `config.toml`
* `CARGO_HOME` is set for each build (unless `cargo_home: false` is set in the build steps)

This also fixes the issue of `cargo` fetching the index on each build (now it can cache the registry in `CARGO_HOME`).

I have also updated the `README.md` to explain local development.

Complements managarm/bootstrap-managarm#102.