### PR TITLE
vcs: add checksumming for 'url' type

### DIFF
--- a/xbstrap/schema.yml
+++ b/xbstrap/schema.yml
@@ -78,6 +78,8 @@ definitions:
                 type: string
             'patch-path-strip':
                 type: integer
+            'checksum':
+                type: string
             # VCS sources.
             'git':
                 type: string
@@ -227,6 +229,8 @@ properties:
                     type: string
                 'patch-path-strip':
                     type: integer
+                'checksum':
+                    type: string
                 # VCS sources.
                 'git':
                     type: string


### PR DESCRIPTION
This allows for specifying checksum type and value for checking when fetching. Currently supported are sha256, sha512 and md5.

When both type and value are not specified, nothing happens. When both are specified, they are checked and an error is throws if there's a mismatch. This behavior does not break old versions, however old versions do not have the schema changes, so they will complain.

An example yaml might look something like this:

```yml
source:
      name: autoconf-v2.64
      subdir: 'ports'
      url: 'https://ftp.gnu.org/gnu/autoconf/autoconf-2.64.tar.xz'
      format: 'tar.xz'
      checksum-type: sha256
      checksum: '32d977213320b8ae76c71175305301197f2b0e04e72d70694bc3d3e2ae6c7248'
      extract_path: 'autoconf-2.64'
      version: '2.64'
```