### PR TITLE
Containerless tools

### DIFF
--- a/xbstrap/__init__.py
+++ b/xbstrap/__init__.py
@@ -69,6 +69,8 @@ def do_runtool(args):
         for name in tools:
             tool_pkgs.append(cfg.get_tool_pkg(name))
 
+    has_containerless = any(x.containerless for x in tool_pkgs)
+
     xbstrap.base.run_program(
         cfg,
         context,
@@ -77,6 +79,7 @@ def do_runtool(args):
         tool_pkgs=tool_pkgs,
         workdir=workdir,
         for_package=for_package,
+        containerless=has_containerless,
     )
 
 

--- a/xbstrap/schema.yml
+++ b/xbstrap/schema.yml
@@ -278,6 +278,8 @@ properties:
                     type: boolean
                 'exports_shared_libs':
                     type: boolean
+                'containerless':
+                    type: boolean
                 'architecture': { type: string }
                 'configure': { $ref: '#/definitions/build_steps' }
                 'compile': { $ref: '#/definitions/build_steps' }


### PR DESCRIPTION
This allows for building tools that don't compile and link against the container but against the host machine. This is useful for building a QEMU in bootstrap for instance:

```yml
tools:
  - name: host-qemu
    containerless: true
    from_source: qemu
    configure:
      - args:
        - '@THIS_SOURCE_DIR@/configure'
        - '--prefix=@PREFIX@'
    compile:
      - args: ['ninja']
    install:
      - args: ['ninja', 'install']
```

This allows the result QEMU to use host libraries, resulting in more features of it being available and not having to ship dozens of host tools.